### PR TITLE
Add option to specify a custom tsconfig path in path-alias

### DIFF
--- a/examples/path-alias/package-lock.json
+++ b/examples/path-alias/package-lock.json
@@ -17,9 +17,13 @@
         },
         "../../packages/path-alias": {
             "name": "@bleed-believer/path-alias",
-            "version": "2.0.1-alpha.0",
+            "version": "2.2.1",
             "license": "MIT",
             "dependencies": {
+                "@bleed-believer/commander": "^0.11.3",
+                "@swc/core": "^1.7.26",
+                "chalk": "^5.3.0",
+                "fast-glob": "^3.3.2",
                 "get-tsconfig": "^4.8.1",
                 "ts-node": "^10.9.2",
                 "tslog": "^4.9.3"
@@ -34,8 +38,7 @@
                 "ava": "^6.1.3",
                 "esmock": "^2.6.7",
                 "proxyquire": "^2.1.3",
-                "sinon": "^19.0.2",
-                "typecript": "^0.0.1-security"
+                "sinon": "^19.0.2"
             },
             "engines": {
                 "node": ">=20.0.0"
@@ -1681,17 +1684,20 @@
         "@bleed-believer/path-alias": {
             "version": "file:../../packages/path-alias",
             "requires": {
+                "@bleed-believer/commander": "^0.11.3",
+                "@swc/core": "^1.7.26",
                 "@types/node": "^22.7.0",
                 "@types/proxyquire": "^1.3.31",
                 "@types/sinon": "^17.0.3",
                 "ava": "^6.1.3",
+                "chalk": "^5.3.0",
                 "esmock": "^2.6.7",
+                "fast-glob": "^3.3.2",
                 "get-tsconfig": "^4.8.1",
                 "proxyquire": "^2.1.3",
                 "sinon": "^19.0.2",
                 "ts-node": "^10.9.2",
-                "tslog": "^4.9.3",
-                "typecript": "^0.0.1-security"
+                "tslog": "^4.9.3"
             }
         },
         "@mole-inc/bin-wrapper": {

--- a/examples/path-alias/package.json
+++ b/examples/path-alias/package.json
@@ -5,6 +5,7 @@
         "build": "clear && rm -rf ./dist && tsc",
         "build:swc": "clear && rm -rf ./dist && swc ./src -d ./dist",
         "start": "./start.sh ./src/index.ts",
+        "start:other": "bb-path-alias start --bb-tsconfig-path ./tsconfig.alt.json ./src/index.ts",
         "start:dist": "npm run build && ./start.sh ./dist/index.js",
         "start:swc": "npm run build:swc && node ./dist/index.js",
         "test": "ava"

--- a/examples/path-alias/src/tool-alt-path/launch.ts
+++ b/examples/path-alias/src/tool-alt-path/launch.ts
@@ -1,0 +1,3 @@
+export function launch(): void {
+    console.log('HahhAh (using alt tsconfig!)');
+}

--- a/examples/path-alias/tsconfig.alt.json
+++ b/examples/path-alias/tsconfig.alt.json
@@ -1,0 +1,24 @@
+{
+    "compilerOptions": {
+        "target": "ES2022",
+        "module": "Node16",
+        "moduleResolution": "Node16",
+
+        "esModuleInterop": true,
+        "verbatimModuleSyntax": true,
+
+        "outDir": "./dist",
+        "rootDir": "./src",
+        "sourceMap": true,
+
+        "strict": true,
+        "baseUrl": "./src",
+        "paths": {
+            "@tool/*": ["./tool-alt-path/*"]
+        }
+    },
+    "exclude": [
+        "./dist",
+        "./node_modules/**"
+    ]
+}

--- a/packages/path-alias/src/custom-hooks.ts
+++ b/packages/path-alias/src/custom-hooks.ts
@@ -1,7 +1,15 @@
 import type { LoadHook, ResolveHook } from 'module';
 import { HookManager } from './hook-manager.js';
+import { TsConfig } from '@tool/ts-config/ts-config.js';
 
-const hookManager = new HookManager();
+const argsFromEnv = JSON.parse(process.env.BLEED_BELIEVER_PATH_ALIAS_ARGS ?? '{}');
+
+const tsConfig = TsConfig.load(
+    process.cwd(),
+    argsFromEnv['--bb-tsconfig-path']?.[0] ?? './tsconfig.json'
+);
+const hookManager = new HookManager(tsConfig);
+
 export const load: LoadHook = async (url, context, defaultLoad) => {
     return hookManager.load(url, context, defaultLoad);
 }

--- a/packages/path-alias/src/hook-manager.ts
+++ b/packages/path-alias/src/hook-manager.ts
@@ -24,11 +24,18 @@ type DefaultResolve = (
 export class HookManager {
     #resolveCache = new Map<string, string>();
     #loadCache = new Map<string, LoadFnOutput>();
-    #tsConfig = TsConfig.load();
+    #tsConfig: TsConfig;
     #swcrc?: SwcOptions;
 
-    #rootDir = resolve(this.#tsConfig.cwd, this.#tsConfig.rootDir);
-    #outDir = resolve(this.#tsConfig.cwd, this.#tsConfig.outDir);
+    #rootDir: string;
+    #outDir: string;
+
+    constructor(tsConfig: TsConfig = TsConfig.load()) {
+        this.#tsConfig = tsConfig;
+
+        this.#rootDir = resolve(this.#tsConfig.cwd, this.#tsConfig.rootDir);
+        this.#outDir = resolve(this.#tsConfig.cwd, this.#tsConfig.outDir);
+    }
 
     async #fileExist(path: string): Promise<boolean> {
         try {


### PR DESCRIPTION
- Adjust node-launcher.ts to skip over flag arguments starting with `--bb-`
  - Pass `--bb-*` arguments as JSON in an environment variable to the spawned project instead
- Parse `BLEED_BELIEVER_PATH_ALIAS_ARGS` env variable in custom-hooks.ts, and initialize `HookManager` with the TSConfig based on the `--bb-tsconfig-path` argument
  - In the process, adjust `HookManager` to take in a `TSConfig` config instead of always calling `TSConfig.load()` with no arguments
- Add example of custom tsconfig path to example project
  - Also pushing an updated package-lock.json since that got generated when I `npm install`ed in the examples folder

Resolves #5 